### PR TITLE
Allow Compact Machine connections

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ repositories {
 dependencies {
    deobfCompile "mezz.jei:jei_${mc_version}:${jei_version}"
    deobfCompile "fastworkbench:FastWorkbench:${mc_version}:${fb_version}"
+   deobfCompile "compact-machines:compactmachines3-${mc_version}:${cm_version}:${cm_build}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,5 +6,7 @@ forge_version=14.23.5.2768
 jei_version=4.13.1.225
 mod_version=1.6.0
 fb_version=1.5.3
+cm_version=3.0.13
+cm_build=b236
 
 # jar signing TODO https://tutorials.darkhax.net/tutorials/jar_signing/

--- a/src/main/java/mrriegel/storagenetwork/block/AbstractBlockConnectable.java
+++ b/src/main/java/mrriegel/storagenetwork/block/AbstractBlockConnectable.java
@@ -2,6 +2,7 @@ package mrriegel.storagenetwork.block;
 
 import mrriegel.storagenetwork.StorageNetwork;
 import mrriegel.storagenetwork.block.master.TileMaster;
+import mrriegel.storagenetwork.data.CapabilityConnectable;
 import mrriegel.storagenetwork.util.UtilTileEntity;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
@@ -25,15 +26,15 @@ public abstract class AbstractBlockConnectable extends BlockContainer {
   public void neighborChanged(IBlockState state, World worldIn, BlockPos pos, Block blockIn, BlockPos fromPos) {
     try {
       TileEntity tile = worldIn.getTileEntity(pos);
-      if (tile != null && tile instanceof IConnectable) {
-        IConnectable conUnitNeedsMaster = (IConnectable) tile;
+      if (tile != null && tile.hasCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null)) {
+        IConnectable conUnitNeedsMaster = tile.getCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null);
         //the new thing needs to find the master of the network. so either my neighbor knows who the master is, 
         //or my neighbor IS the master
         TileEntity tileLoop = null;
         for (BlockPos p : UtilTileEntity.getSides(pos)) {
           tileLoop = worldIn.getTileEntity(p);
-          if (tileLoop instanceof IConnectable) {
-            IConnectable conUnit = (IConnectable) tileLoop;
+          if (tileLoop != null && tileLoop.hasCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null)) {
+            IConnectable conUnit = tileLoop.getCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null);
             if (conUnit.getMaster() != null) {
               conUnitNeedsMaster.setMaster((conUnit).getMaster());
             }
@@ -52,10 +53,10 @@ public abstract class AbstractBlockConnectable extends BlockContainer {
 
   public void setConnections(World worldIn, BlockPos pos, IBlockState state, boolean refresh) {
     TileEntity myselfTile = worldIn.getTileEntity(pos);
-    if (myselfTile == null || myselfTile instanceof IConnectable == false) {
+    if (myselfTile == null || !myselfTile.hasCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null)) {
       return;
     }
-    IConnectable myselfConnect = (IConnectable) myselfTile;
+    IConnectable myselfConnect = myselfTile.getCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null);
     if (myselfConnect.getMaster() == null) {
       for (BlockPos p : UtilTileEntity.getSides(pos)) {
         if (worldIn.getTileEntity(p) instanceof TileMaster) {
@@ -77,8 +78,8 @@ public abstract class AbstractBlockConnectable extends BlockContainer {
           ///seems like i can delete this superhack but im not sure, it never executes
           for (BlockPos p : ((TileMaster) tileMaster).getConnectables()) {
             TileEntity tileCurrent = worldIn.getTileEntity(p);
-            if (worldIn.getChunkFromBlockCoords(p).isLoaded() && tileCurrent instanceof IConnectable) {
-              ((IConnectable) tileCurrent).setMaster(null);
+            if (worldIn.getChunkFromBlockCoords(p).isLoaded() && tileCurrent.hasCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null)) {
+              tileCurrent.getCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null).setMaster(null);
               worldIn.markChunkDirty(p, tileCurrent);
             }
           }
@@ -99,8 +100,8 @@ public abstract class AbstractBlockConnectable extends BlockContainer {
         continue;
       }
       TileEntity nhbr = world.getTileEntity(posBeside);
-      if (nhbr instanceof IConnectable) {//
-        IConnectable nbrConn = (IConnectable) nhbr;
+      if (nhbr != null && nhbr.hasCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null)) {//
+        IConnectable nbrConn = nhbr.getCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null);
         if (nbrConn.getMaster() != null) {
           nbrConn.setMaster(null);
           world.markChunkDirty(posBeside, world.getTileEntity(posBeside));

--- a/src/main/java/mrriegel/storagenetwork/block/IConnectable.java
+++ b/src/main/java/mrriegel/storagenetwork/block/IConnectable.java
@@ -10,6 +10,9 @@ import net.minecraft.util.math.BlockPos;
  *
  */
 public interface IConnectable {
+  public int getMasterDimension();
+
+  public void setMasterDimension(int dimMaster);
 
   public BlockPos getMaster();
 

--- a/src/main/java/mrriegel/storagenetwork/block/IConnectable.java
+++ b/src/main/java/mrriegel/storagenetwork/block/IConnectable.java
@@ -14,7 +14,11 @@ public interface IConnectable {
 
   public void setMasterDimension(int dimMaster);
 
-  public BlockPos getMaster();
+  public BlockPos getMasterPos();
 
-  public void setMaster(BlockPos master);
+  public void setMasterPos(BlockPos master);
+
+  public int getDim();
+
+  public BlockPos getPos();
 }

--- a/src/main/java/mrriegel/storagenetwork/block/TileConnectable.java
+++ b/src/main/java/mrriegel/storagenetwork/block/TileConnectable.java
@@ -68,9 +68,9 @@ public class TileConnectable extends TileEntity {
   public void onChunkUnload() {
     if (ConfigHandler.reloadNetworkWhenUnloadChunk && connectable != null && connectable.getMaster() != null) {
       try {
-        TileEntity maybeMaster = world.getTileEntity(connectable.getMaster());
-        if (maybeMaster instanceof TileMaster) {
-          ((TileMaster) maybeMaster).refreshNetwork();
+        TileMaster maybeMaster = CapabilityConnectable.getTileMasterForConnectable(connectable);
+        if (maybeMaster != null) {
+          maybeMaster.refreshNetwork();
         }
       }
       catch (Exception e) {
@@ -88,6 +88,7 @@ public class TileConnectable extends TileEntity {
     return super.hasCapability(capability, facing);
   }
 
+  @SuppressWarnings("unchecked")
   @Nullable
   @Override
   public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing) {

--- a/src/main/java/mrriegel/storagenetwork/block/TileConnectable.java
+++ b/src/main/java/mrriegel/storagenetwork/block/TileConnectable.java
@@ -1,58 +1,55 @@
 package mrriegel.storagenetwork.block;
 
-import com.google.common.reflect.TypeToken;
-import com.google.gson.Gson;
 import mrriegel.storagenetwork.StorageNetwork;
 import mrriegel.storagenetwork.block.master.TileMaster;
 import mrriegel.storagenetwork.config.ConfigHandler;
+import mrriegel.storagenetwork.data.CapabilityConnectable;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.play.server.SPacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.common.capabilities.Capability;
+
+import javax.annotation.Nullable;
 
 /**
  * Base class for Cable, Control, Request
  *
  */
-public class TileConnectable extends TileEntity implements IConnectable {
+public class TileConnectable extends TileEntity {
 
-  protected BlockPos posMaster;
+  protected CapabilityConnectable connectable;
+
+  public TileConnectable() {
+    connectable = new CapabilityConnectable();
+  }
+
+  @Override
+  public void readFromNBT(NBTTagCompound compound) {
+    super.readFromNBT(compound);
+    if(compound.hasKey("connectable")) {
+      connectable.deserializeNBT(compound.getCompoundTag("connectable"));
+  }
+  }
+
+  @Override
+  public NBTTagCompound writeToNBT(NBTTagCompound compound) {
+    compound.setTag("connectable", connectable.serializeNBT());
+    return super.writeToNBT(compound);
+  }
 
   @Override
   public NBTTagCompound getUpdateTag() {
     return writeToNBT(new NBTTagCompound());
   }
 
-  @SuppressWarnings("serial")
-  @Override
-  public void readFromNBT(NBTTagCompound compound) {
-    super.readFromNBT(compound);
-    posMaster = new Gson().fromJson(compound.getString("master"), new TypeToken<BlockPos>() {}.getType());
-  }
-
-  @Override
-  public NBTTagCompound writeToNBT(NBTTagCompound compound) {
-    super.writeToNBT(compound);
-    compound.setString("master", new Gson().toJson(posMaster));
-    return compound;
-  }
-
   @Override
   public boolean shouldRefresh(World world, BlockPos pos, IBlockState oldState, IBlockState newSate) {
     return oldState.getBlock() != newSate.getBlock();
-  }
-
-  @Override
-  public BlockPos getMaster() {
-    return posMaster;
-  }
-
-  @Override
-  public void setMaster(BlockPos master) {
-    this.posMaster = master;
   }
 
   @Override
@@ -69,9 +66,9 @@ public class TileConnectable extends TileEntity implements IConnectable {
 
   @Override
   public void onChunkUnload() {
-    if (ConfigHandler.reloadNetworkWhenUnloadChunk && posMaster != null) {
+    if (ConfigHandler.reloadNetworkWhenUnloadChunk && connectable != null && connectable.getMaster() != null) {
       try {
-        TileEntity maybeMaster = world.getTileEntity(posMaster);
+        TileEntity maybeMaster = world.getTileEntity(connectable.getMaster());
         if (maybeMaster instanceof TileMaster) {
           ((TileMaster) maybeMaster).refreshNetwork();
         }
@@ -80,5 +77,28 @@ public class TileConnectable extends TileEntity implements IConnectable {
         StorageNetwork.instance.logger.error("Error on chunk unload ", e);
       }
     }
+  }
+
+  @Override
+  public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing) {
+    if(capability == CapabilityConnectable.CONNECTABLE_CAPABILITY) {
+      return true;
+    }
+
+    return super.hasCapability(capability, facing);
+  }
+
+  @Nullable
+  @Override
+  public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing) {
+    if(capability == CapabilityConnectable.CONNECTABLE_CAPABILITY) {
+      return (T) connectable;
+    }
+
+    return super.getCapability(capability, facing);
+  }
+
+  public BlockPos getMaster() {
+    return connectable.getMaster();
   }
 }

--- a/src/main/java/mrriegel/storagenetwork/block/TileConnectable.java
+++ b/src/main/java/mrriegel/storagenetwork/block/TileConnectable.java
@@ -29,6 +29,13 @@ public class TileConnectable extends TileEntity {
   }
 
   @Override
+  public void setPos(BlockPos posIn) {
+    super.setPos(posIn);
+    connectable.setPos(posIn);
+    connectable.setDimension(world.provider.getDimension());
+  }
+
+  @Override
   public void readFromNBT(NBTTagCompound compound) {
     super.readFromNBT(compound);
     if(compound.hasKey("connectable")) {
@@ -66,7 +73,7 @@ public class TileConnectable extends TileEntity {
 
   @Override
   public void onChunkUnload() {
-    if (ConfigHandler.reloadNetworkWhenUnloadChunk && connectable != null && connectable.getMaster() != null) {
+    if (ConfigHandler.reloadNetworkWhenUnloadChunk && connectable != null && connectable.getMasterPos() != null) {
       try {
         TileMaster maybeMaster = CapabilityConnectable.getTileMasterForConnectable(connectable);
         if (maybeMaster != null) {
@@ -100,6 +107,6 @@ public class TileConnectable extends TileEntity {
   }
 
   public BlockPos getMaster() {
-    return connectable.getMaster();
+    return connectable.getMasterPos();
   }
 }

--- a/src/main/java/mrriegel/storagenetwork/block/cable/BlockCable.java
+++ b/src/main/java/mrriegel/storagenetwork/block/cable/BlockCable.java
@@ -187,7 +187,7 @@ public class BlockCable extends AbstractBlockConnectable {
     boolean storage = false;
     boolean first = false;
     //fill in newMap based on current storage connection
-    if (facingStorage != null && getConnectionTypeBetween(world, pos, pos.offset(facingStorage)) == EnumCableType.STORAGE) {
+    if (facingStorage != null && getConnectionTypeBetween(world, pos, facingStorage) == EnumCableType.STORAGE) {
       newMap.put(facingStorage, EnumCableType.STORAGE);
       storage = true;
       first = true;
@@ -199,7 +199,7 @@ public class BlockCable extends AbstractBlockConnectable {
         continue;
       }
       //what connection type is possible here before i save it (conn, null, str)
-      EnumCableType connectType = getConnectionTypeBetween(world, pos, pos.offset(facing));
+      EnumCableType connectType = getConnectionTypeBetween(world, pos, facing);
       if (connectType == EnumCableType.STORAGE) {
         //make sure it only picks ONE storage connection to main
         if (!storage) {
@@ -359,10 +359,15 @@ public class BlockCable extends AbstractBlockConnectable {
     return new AxisAlignedBB(x1, z1, y1, x2, z2, y2);
   }
 
-  protected EnumCableType getConnectionTypeBetween(IBlockAccess world, BlockPos posTarget, BlockPos posHere) {
+  protected EnumCableType getConnectionTypeBetween(IBlockAccess world, BlockPos posTarget, EnumFacing facing) {
+    BlockPos posHere = posTarget.offset(facing);
     TileEntity tileHere = world.getTileEntity(posHere);
     Block targetBlock = world.getBlockState(posTarget).getBlock();
-    if (tileHere  != null && tileHere.hasCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null) || tileHere instanceof ICable || tileHere instanceof TileMaster) {
+
+    boolean isConnectable = tileHere  != null && tileHere.hasCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, facing.getOpposite());
+    boolean isCableOrMaster = tileHere instanceof ICable || tileHere instanceof TileMaster;
+
+    if (isConnectable || isCableOrMaster) {
       return EnumCableType.CONNECT;
     }
     if (targetBlock == ModBlocks.kabel) {

--- a/src/main/java/mrriegel/storagenetwork/block/cable/BlockCable.java
+++ b/src/main/java/mrriegel/storagenetwork/block/cable/BlockCable.java
@@ -14,6 +14,7 @@ import mrriegel.storagenetwork.api.ICable;
 import mrriegel.storagenetwork.block.AbstractBlockConnectable;
 import mrriegel.storagenetwork.block.IConnectable;
 import mrriegel.storagenetwork.block.master.TileMaster;
+import mrriegel.storagenetwork.data.CapabilityConnectable;
 import mrriegel.storagenetwork.data.EnumCableType;
 import mrriegel.storagenetwork.gui.GuiHandler;
 import mrriegel.storagenetwork.registry.ModBlocks;
@@ -361,7 +362,7 @@ public class BlockCable extends AbstractBlockConnectable {
   protected EnumCableType getConnectionTypeBetween(IBlockAccess world, BlockPos posTarget, BlockPos posHere) {
     TileEntity tileHere = world.getTileEntity(posHere);
     Block targetBlock = world.getBlockState(posTarget).getBlock();
-    if (tileHere instanceof IConnectable || tileHere instanceof ICable || tileHere instanceof TileMaster) {
+    if (tileHere  != null && tileHere.hasCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null) || tileHere instanceof ICable || tileHere instanceof TileMaster) {
       return EnumCableType.CONNECT;
     }
     if (targetBlock == ModBlocks.kabel) {

--- a/src/main/java/mrriegel/storagenetwork/block/cable/TileCable.java
+++ b/src/main/java/mrriegel/storagenetwork/block/cable/TileCable.java
@@ -19,6 +19,7 @@ import mrriegel.storagenetwork.data.StackWrapper;
 import mrriegel.storagenetwork.item.ItemUpgrade;
 import mrriegel.storagenetwork.registry.ModBlocks;
 import mrriegel.storagenetwork.registry.ModItems;
+import mrriegel.storagenetwork.util.DimPos;
 import mrriegel.storagenetwork.util.UtilInventory;
 import mrriegel.storagenetwork.util.UtilTileEntity;
 import net.minecraft.entity.player.EntityPlayer;
@@ -212,12 +213,21 @@ public class TileCable extends TileConnectable implements IInventory, ICableStor
 
   //    TileMaster master;
   private boolean doesPassOperationFilterLimit() {
-    TileMaster master = (TileMaster) this.world.getTileEntity(this.getMaster());
+    if(connectable.getMasterPos() == null) {
+      return false;
+    }
+
+    DimPos masterDimPos = new DimPos(connectable.getMasterDimension(), connectable.getMasterPos());
+    TileMaster master = masterDimPos.getTileEntity(TileMaster.class);
+    if(master == null) {
+      return false;
+    }
+
     if (this.getUpgradesOfType(ItemUpgrade.OPERATION) < 1) {
       return true;
     }
     //ok operation upgrade does NOT exist
-    //    TileMaster m = (TileMaster) world.getTileEntity(cable.getMaster());
+    //    TileMaster m = (TileMaster) world.getTileEntity(cable.getMasterPos());
     if (getOperationStack() == null || getOperationStack().isEmpty()) {
       return true;
     }

--- a/src/main/java/mrriegel/storagenetwork/block/control/BlockControl.java
+++ b/src/main/java/mrriegel/storagenetwork/block/control/BlockControl.java
@@ -6,6 +6,7 @@ import mrriegel.storagenetwork.CreativeTab;
 import mrriegel.storagenetwork.StorageNetwork;
 import mrriegel.storagenetwork.block.AbstractBlockConnectable;
 import mrriegel.storagenetwork.block.IConnectable;
+import mrriegel.storagenetwork.data.CapabilityConnectable;
 import mrriegel.storagenetwork.gui.GuiHandler;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
@@ -72,10 +73,10 @@ public class BlockControl extends AbstractBlockConnectable {
   @Override
   public boolean onBlockActivated(World worldIn, BlockPos pos, IBlockState state, EntityPlayer playerIn, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
     TileEntity tileHere = worldIn.getTileEntity(pos);
-    if (!(tileHere instanceof IConnectable)) {
+    if (tileHere == null || !tileHere.hasCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null)) {
       return false;
     }
-    IConnectable tile = (IConnectable) tileHere;
+    IConnectable tile = tileHere.getCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null);
     if (!worldIn.isRemote && tile.getMaster() != null) {
       playerIn.openGui(StorageNetwork.instance, GuiHandler.CONTROLLER, worldIn, pos.getX(), pos.getY(), pos.getZ());
       return true;

--- a/src/main/java/mrriegel/storagenetwork/block/control/BlockControl.java
+++ b/src/main/java/mrriegel/storagenetwork/block/control/BlockControl.java
@@ -77,7 +77,7 @@ public class BlockControl extends AbstractBlockConnectable {
       return false;
     }
     IConnectable tile = tileHere.getCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null);
-    if (!worldIn.isRemote && tile.getMaster() != null) {
+    if (!worldIn.isRemote && tile.getMasterPos() != null) {
       playerIn.openGui(StorageNetwork.instance, GuiHandler.CONTROLLER, worldIn, pos.getX(), pos.getY(), pos.getZ());
       return true;
     }

--- a/src/main/java/mrriegel/storagenetwork/block/master/BlockMaster.java
+++ b/src/main/java/mrriegel/storagenetwork/block/master/BlockMaster.java
@@ -12,6 +12,7 @@ import mrriegel.storagenetwork.CreativeTab;
 import mrriegel.storagenetwork.StorageNetwork;
 import mrriegel.storagenetwork.block.IConnectable;
 import mrriegel.storagenetwork.data.CapabilityConnectable;
+import mrriegel.storagenetwork.util.DimPos;
 import mrriegel.storagenetwork.util.UtilTileEntity;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
@@ -63,8 +64,8 @@ public class BlockMaster extends BlockContainer {
       tileHere = worldIn.getTileEntity(p);
       if (tileHere != null && tileHere.hasCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null)) {
         connect = tileHere.getCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null);
-        if (connect.getMaster() != null && !connect.getMaster().equals(pos) && connect.getMasterDimension() != worldIn.provider.getDimension()) {
-          masterPos = connect.getMaster();
+        if (connect.getMasterPos() != null && !connect.getMasterPos().equals(pos) && connect.getMasterDimension() != worldIn.provider.getDimension()) {
+          masterPos = connect.getMasterPos();
           break;
         }
       }
@@ -102,8 +103,8 @@ public class BlockMaster extends BlockContainer {
     playerIn.sendMessage(new TextComponentString(TextFormatting.LIGHT_PURPLE + StorageNetwork.lang("chat.master.emptyslots") + tileMaster.emptySlots()));
     playerIn.sendMessage(new TextComponentString(TextFormatting.DARK_AQUA + StorageNetwork.lang("chat.master.connectables") + tileMaster.getConnectables().size()));
     Map<String, Integer> mapNamesToCount = new HashMap<String, Integer>();
-    for (BlockPos p : tileMaster.getConnectables()) {
-      String block = worldIn.getBlockState(p).getBlock().getLocalizedName();
+    for (DimPos p : tileMaster.getConnectables()) {
+      String block = p.getBlockState().getBlock().getLocalizedName();
       mapNamesToCount.put(block, mapNamesToCount.get(block) != null ? (mapNamesToCount.get(block) + 1) : 1);
     }
     List<Entry<String, Integer>> listDisplayStrings = Lists.newArrayList();

--- a/src/main/java/mrriegel/storagenetwork/block/master/BlockMaster.java
+++ b/src/main/java/mrriegel/storagenetwork/block/master/BlockMaster.java
@@ -11,6 +11,7 @@ import com.google.common.collect.Lists;
 import mrriegel.storagenetwork.CreativeTab;
 import mrriegel.storagenetwork.StorageNetwork;
 import mrriegel.storagenetwork.block.IConnectable;
+import mrriegel.storagenetwork.data.CapabilityConnectable;
 import mrriegel.storagenetwork.util.UtilTileEntity;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
@@ -60,8 +61,8 @@ public class BlockMaster extends BlockContainer {
     IConnectable connect = null;
     for (BlockPos p : UtilTileEntity.getSides(pos)) {
       tileHere = worldIn.getTileEntity(p);
-      if (tileHere instanceof IConnectable) {
-        connect = (IConnectable) tileHere;
+      if (tileHere != null && tileHere.hasCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null)) {
+        connect = tileHere.getCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null);
         if (connect.getMaster() != null && !connect.getMaster().equals(pos)) {
           masterPos = connect.getMaster();
           break;

--- a/src/main/java/mrriegel/storagenetwork/block/master/BlockMaster.java
+++ b/src/main/java/mrriegel/storagenetwork/block/master/BlockMaster.java
@@ -63,7 +63,7 @@ public class BlockMaster extends BlockContainer {
       tileHere = worldIn.getTileEntity(p);
       if (tileHere != null && tileHere.hasCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null)) {
         connect = tileHere.getCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null);
-        if (connect.getMaster() != null && !connect.getMaster().equals(pos)) {
+        if (connect.getMaster() != null && !connect.getMaster().equals(pos) && connect.getMasterDimension() != worldIn.provider.getDimension()) {
           masterPos = connect.getMaster();
           break;
         }

--- a/src/main/java/mrriegel/storagenetwork/block/master/TileMaster.java
+++ b/src/main/java/mrriegel/storagenetwork/block/master/TileMaster.java
@@ -20,6 +20,7 @@ import mrriegel.storagenetwork.block.cable.ProcessRequestModel.ProcessStatus;
 import mrriegel.storagenetwork.block.cable.TileCable;
 import mrriegel.storagenetwork.block.master.RecentSlotPointer.StackSlot;
 import mrriegel.storagenetwork.config.ConfigHandler;
+import mrriegel.storagenetwork.data.CapabilityConnectable;
 import mrriegel.storagenetwork.data.EnumFilterDirection;
 import mrriegel.storagenetwork.data.FilterItem;
 import mrriegel.storagenetwork.data.StackWrapper;
@@ -148,13 +149,13 @@ public class TileMaster extends TileEntity implements ITickable {
         world.removeTileEntity(blockPos);
         continue;
       }
-      if ((tileHere instanceof IConnectable
-          || tileHere instanceof ICable)
-          && !getConnectables().contains(blockPos)) {
+
+      if (tileHere != null && (tileHere.hasCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null) || tileHere instanceof ICable) && !getConnectables().contains(blockPos)) {
         getConnectables().add(blockPos);
-        if (tileHere instanceof IConnectable) {
-          ((IConnectable) tileHere).setMaster(this.pos);
+        if(tileHere.hasCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null)) {
+          tileHere.getCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null).setMaster(this.pos);
         }
+
         chunk.setModified(true);
         addConnectables(blockPos);
       }

--- a/src/main/java/mrriegel/storagenetwork/block/master/TileMaster.java
+++ b/src/main/java/mrriegel/storagenetwork/block/master/TileMaster.java
@@ -33,6 +33,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.play.server.SPacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ITickable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
@@ -131,7 +132,9 @@ public class TileMaster extends TileEntity implements ITickable {
     if (pos == null || world == null || this.getWorld().isBlockLoaded(pos) == false) {
       return;
     }
-    for (BlockPos blockPos : UtilTileEntity.getSides(pos)) {
+    for (EnumFacing direction : EnumFacing.values()) {
+      BlockPos blockPos = pos.offset(direction);
+
       if (this.getWorld().isBlockLoaded(blockPos) == false) {
         continue;
       }
@@ -150,10 +153,13 @@ public class TileMaster extends TileEntity implements ITickable {
         continue;
       }
 
-      if (tileHere != null && (tileHere.hasCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null) || tileHere instanceof ICable) && !getConnectables().contains(blockPos)) {
+      if (tileHere != null && (tileHere.hasCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, direction.getOpposite()) || tileHere instanceof ICable) && !getConnectables().contains(blockPos)) {
         getConnectables().add(blockPos);
-        if(tileHere.hasCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null)) {
-          tileHere.getCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null).setMaster(this.pos);
+        if(tileHere.hasCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, direction.getOpposite())) {
+          IConnectable capabilityConnectable = tileHere.getCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, direction.getOpposite());
+          capabilityConnectable.setMaster(this.pos);
+          capabilityConnectable.setMasterDimension(this.world.provider.getDimension());
+          tileHere.markDirty();
         }
 
         chunk.setModified(true);

--- a/src/main/java/mrriegel/storagenetwork/block/request/BlockRequest.java
+++ b/src/main/java/mrriegel/storagenetwork/block/request/BlockRequest.java
@@ -6,6 +6,7 @@ import mrriegel.storagenetwork.CreativeTab;
 import mrriegel.storagenetwork.StorageNetwork;
 import mrriegel.storagenetwork.block.AbstractBlockConnectable;
 import mrriegel.storagenetwork.block.IConnectable;
+import mrriegel.storagenetwork.data.CapabilityConnectable;
 import mrriegel.storagenetwork.gui.GuiHandler;
 import mrriegel.storagenetwork.util.UtilTileEntity;
 import net.minecraft.block.material.Material;
@@ -73,10 +74,10 @@ public class BlockRequest extends AbstractBlockConnectable {
   @Override
   public boolean onBlockActivated(World worldIn, BlockPos pos, IBlockState state, EntityPlayer playerIn, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
     TileEntity tileHere = worldIn.getTileEntity(pos);
-    if (!(tileHere instanceof IConnectable)) {
+    if (tileHere == null || !tileHere.hasCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null)) {
       return false;
     }
-    IConnectable tile = (IConnectable) tileHere;
+    IConnectable tile = tileHere.getCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null);
     if (!worldIn.isRemote && tile.getMaster() != null) {
       playerIn.openGui(StorageNetwork.instance, GuiHandler.REQUEST, worldIn, pos.getX(), pos.getY(), pos.getZ());
       return true;

--- a/src/main/java/mrriegel/storagenetwork/block/request/BlockRequest.java
+++ b/src/main/java/mrriegel/storagenetwork/block/request/BlockRequest.java
@@ -78,7 +78,7 @@ public class BlockRequest extends AbstractBlockConnectable {
       return false;
     }
     IConnectable tile = tileHere.getCapability(CapabilityConnectable.CONNECTABLE_CAPABILITY, null);
-    if (!worldIn.isRemote && tile.getMaster() != null) {
+    if (!worldIn.isRemote && tile.getMasterPos() != null) {
       playerIn.openGui(StorageNetwork.instance, GuiHandler.REQUEST, worldIn, pos.getX(), pos.getY(), pos.getZ());
       return true;
     }

--- a/src/main/java/mrriegel/storagenetwork/compat/ConnectableNullHandler.java
+++ b/src/main/java/mrriegel/storagenetwork/compat/ConnectableNullHandler.java
@@ -1,0 +1,45 @@
+package mrriegel.storagenetwork.compat;
+
+import mrriegel.storagenetwork.block.IConnectable;
+import mrriegel.storagenetwork.data.CapabilityConnectable;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.common.capabilities.Capability;
+import org.dave.compactmachines3.integration.AbstractNullHandler;
+import org.dave.compactmachines3.integration.CapabilityNullHandler;
+
+@CapabilityNullHandler
+public class ConnectableNullHandler extends AbstractNullHandler implements IConnectable {
+    @Override
+    public Capability getCapability() {
+        return CapabilityConnectable.CONNECTABLE_CAPABILITY;
+    }
+
+
+    @Override
+    public int getMasterDimension() {
+        return 0;
+    }
+
+    @Override
+    public void setMasterDimension(int dimMaster) {
+    }
+
+    @Override
+    public BlockPos getMasterPos() {
+        return new BlockPos(0,0,0);
+    }
+
+    @Override
+    public void setMasterPos(BlockPos master) {
+    }
+
+    @Override
+    public int getDim() {
+        return 0;
+    }
+
+    @Override
+    public BlockPos getPos() {
+        return new BlockPos(0, 0, 0);
+    }
+}

--- a/src/main/java/mrriegel/storagenetwork/data/CapabilityConnectable.java
+++ b/src/main/java/mrriegel/storagenetwork/data/CapabilityConnectable.java
@@ -1,0 +1,80 @@
+package mrriegel.storagenetwork.data;
+
+import mrriegel.storagenetwork.block.IConnectable;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTUtil;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.util.INBTSerializable;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.Callable;
+
+public class CapabilityConnectable implements IConnectable, INBTSerializable<NBTTagCompound> {
+    protected BlockPos posMaster;
+
+    @CapabilityInject(IConnectable.class)
+    public static Capability<IConnectable> CONNECTABLE_CAPABILITY = null;
+
+    public static void initCapability() {
+        CapabilityManager.INSTANCE.register(IConnectable.class, new Storage(), new Factory());
+    }
+
+    @Override
+    public BlockPos getMaster() {
+        return posMaster;
+    }
+
+    @Override
+    public void setMaster(BlockPos master) {
+        this.posMaster = master;
+    }
+
+    @Override
+    public NBTTagCompound serializeNBT() {
+        BlockPos masterPos = this.getMaster();
+        NBTTagCompound masterData = NBTUtil.createPosTag(masterPos);
+
+        NBTTagCompound result = new NBTTagCompound();
+        result.setTag("master", masterData);
+
+        return result;
+
+    }
+
+    @Override
+    public void deserializeNBT(NBTTagCompound nbt) {
+        NBTTagCompound masterData = nbt.getCompoundTag("master");
+
+        BlockPos masterPos = NBTUtil.getPosFromTag(masterData);
+        this.setMaster(masterPos);
+    }
+
+
+    private static class Factory implements Callable<IConnectable> {
+
+        @Override
+        public IConnectable call() throws Exception {
+            return new CapabilityConnectable();
+        }
+    }
+
+    private static class Storage implements Capability.IStorage<IConnectable> {
+        @Nullable
+        @Override
+        public NBTBase writeNBT(Capability<IConnectable> capability, IConnectable rawInstance, EnumFacing side) {
+            CapabilityConnectable instance = (CapabilityConnectable)rawInstance;
+            return instance.serializeNBT();
+        }
+
+        @Override
+        public void readNBT(Capability<IConnectable> capability, IConnectable rawInstance, EnumFacing side, NBTBase nbt) {
+            CapabilityConnectable instance = (CapabilityConnectable)rawInstance;
+            instance.deserializeNBT((NBTTagCompound) nbt);
+        }
+    }
+}

--- a/src/main/java/mrriegel/storagenetwork/data/CapabilityConnectable.java
+++ b/src/main/java/mrriegel/storagenetwork/data/CapabilityConnectable.java
@@ -22,6 +22,8 @@ import java.util.concurrent.Callable;
 public class CapabilityConnectable implements IConnectable, INBTSerializable<NBTTagCompound> {
     protected int dimMaster;
     protected BlockPos posMaster;
+    protected int dim;
+    protected BlockPos pos;
 
     @CapabilityInject(IConnectable.class)
     public static Capability<IConnectable> CONNECTABLE_CAPABILITY = null;
@@ -40,7 +42,7 @@ public class CapabilityConnectable implements IConnectable, INBTSerializable<NBT
     @Nullable
     public static TileMaster getTileMasterForConnectable(@Nonnull IConnectable connectable) {
         WorldServer world = DimensionManager.getWorld(connectable.getMasterDimension());
-        TileEntity tileEntity = world.getTileEntity(connectable.getMaster());
+        TileEntity tileEntity = world.getTileEntity(connectable.getMasterPos());
         if(tileEntity instanceof TileMaster) {
             return (TileMaster) tileEntity;
         }
@@ -59,13 +61,32 @@ public class CapabilityConnectable implements IConnectable, INBTSerializable<NBT
     }
 
     @Override
-    public BlockPos getMaster() {
+    public BlockPos getMasterPos() {
         return posMaster;
     }
 
     @Override
-    public void setMaster(BlockPos master) {
+    public void setMasterPos(BlockPos master) {
         this.posMaster = master;
+    }
+
+
+    @Override
+    public int getDim() {
+        return dim;
+    }
+
+    public void setDimension(int dim) {
+        this.dim = dim;
+    }
+
+    @Override
+    public BlockPos getPos() {
+        return pos;
+    }
+
+    public void setPos(BlockPos pos) {
+        this.pos = pos;
     }
 
     @Override
@@ -78,8 +99,11 @@ public class CapabilityConnectable implements IConnectable, INBTSerializable<NBT
         NBTTagCompound masterData = NBTUtil.createPosTag(posMaster);
         masterData.setInteger("Dim", dimMaster);
 
+        NBTTagCompound selfData = NBTUtil.createPosTag(pos);
+        selfData.setInteger("Dim", dim);
 
         result.setTag("master", masterData);
+        result.setTag("self", selfData);
 
         return result;
 
@@ -88,10 +112,12 @@ public class CapabilityConnectable implements IConnectable, INBTSerializable<NBT
     @Override
     public void deserializeNBT(NBTTagCompound nbt) {
         NBTTagCompound masterData = nbt.getCompoundTag("master");
-
-        BlockPos masterPos = NBTUtil.getPosFromTag(masterData);
-        this.setMaster(masterPos);
+        this.setMasterPos(NBTUtil.getPosFromTag(masterData));
         this.setMasterDimension(masterData.getInteger("Dim"));
+
+        NBTTagCompound selfData = nbt.getCompoundTag("self");
+        this.setPos(NBTUtil.getPosFromTag(selfData));
+        this.setDimension(selfData.getInteger("Dim"));
     }
 
 

--- a/src/main/java/mrriegel/storagenetwork/gui/fb/ContainerFastRequest.java
+++ b/src/main/java/mrriegel/storagenetwork/gui/fb/ContainerFastRequest.java
@@ -29,7 +29,10 @@ public class ContainerFastRequest extends ContainerFastNetworkCrafter {
       else this.craftMatrix.setInventorySlotContents(i, tile.matrix.getOrDefault(i, ItemStack.EMPTY));
     }
     SlotCraftingNetwork slotCraftOutput = new SlotCraftingNetwork(player, craftMatrix, craftResult, 0, 101, 128);
-    slotCraftOutput.setTileMaster((TileMaster) tile.getWorld().getTileEntity(tile.getMaster()));
+    BlockPos masterPos = tile.getMaster();
+    TileMaster masterTile = (TileMaster) tile.getWorld().getTileEntity(masterPos);
+
+    slotCraftOutput.setTileMaster(masterTile);
     this.addSlotToContainer(slotCraftOutput);
     bindGrid();
     bindPlayerInvo(player.inventory);

--- a/src/main/java/mrriegel/storagenetwork/proxy/CommonProxy.java
+++ b/src/main/java/mrriegel/storagenetwork/proxy/CommonProxy.java
@@ -2,6 +2,7 @@ package mrriegel.storagenetwork.proxy;
 
 import mrriegel.storagenetwork.StorageNetwork;
 import mrriegel.storagenetwork.config.ConfigHandler;
+import mrriegel.storagenetwork.data.CapabilityConnectable;
 import mrriegel.storagenetwork.gui.GuiHandler;
 import mrriegel.storagenetwork.jei.JeiSettings;
 import mrriegel.storagenetwork.registry.PacketRegistry;
@@ -15,6 +16,7 @@ import net.minecraftforge.fml.common.network.NetworkRegistry;
 public class CommonProxy {
 
   public void preInit(FMLPreInitializationEvent event) {
+    CapabilityConnectable.initCapability();
     ConfigHandler.refreshConfig(event.getSuggestedConfigurationFile());
     JeiSettings.setJeiLoaded(Loader.isModLoaded("jei"));
     PacketRegistry.init();

--- a/src/main/java/mrriegel/storagenetwork/util/DimPos.java
+++ b/src/main/java/mrriegel/storagenetwork/util/DimPos.java
@@ -1,0 +1,101 @@
+package mrriegel.storagenetwork.util;
+
+import com.google.common.base.Objects;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTUtil;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.common.util.INBTSerializable;
+
+import javax.annotation.Nullable;
+
+public class DimPos implements INBTSerializable<NBTTagCompound> {
+    public int dimension;
+    private BlockPos pos;
+
+    public DimPos() {
+    }
+
+    public DimPos(int dimension, BlockPos pos) {
+        this.dimension = dimension;
+        this.pos = pos;
+    }
+
+    public DimPos(World world, BlockPos pos) {
+        this.dimension = world.provider.getDimension();
+        this.pos = pos;
+    }
+
+    @Nullable
+    public World getWorld() {
+        return DimensionManager.getWorld(this.dimension);
+    }
+
+    public BlockPos getBlockPos() {
+        return pos;
+    }
+
+    public IBlockState getBlockState() {
+        return getWorld().getBlockState(getBlockPos());
+    }
+
+    public <V> V getTileEntity(Class<V> tileEntityClassOrInterface) {
+        TileEntity tileEntity = getWorld().getTileEntity(getBlockPos());
+        if(tileEntity == null) {
+            return null;
+        }
+
+        if(!tileEntityClassOrInterface.isAssignableFrom(tileEntity.getClass())) {
+            return null;
+        }
+
+        return (V) tileEntity;
+    }
+
+    public boolean isLoaded() {
+        if(getWorld() == null) {
+            return false;
+        }
+
+        return getWorld().isBlockLoaded(pos);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DimPos dimPos = (DimPos) o;
+        return dimension == dimPos.dimension &&
+                Objects.equal(pos, dimPos.pos);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(dimension, pos);
+    }
+
+    @Override
+    public String toString() {
+        return "[" +
+                "dimension=" + dimension +
+                ", pos=" + pos +
+                ']';
+    }
+
+
+    @Override
+    public NBTTagCompound serializeNBT() {
+        NBTTagCompound result = NBTUtil.createPosTag(this.pos);
+        result.setInteger("Dim", this.dimension);
+        return result;
+    }
+
+    @Override
+    public void deserializeNBT(NBTTagCompound nbt) {
+        this.pos = NBTUtil.getPosFromTag(nbt);
+        this.dimension = nbt.getInteger("Dim");
+    }
+}


### PR DESCRIPTION
It requires multiple changes:
- Connectables must be a capability
- Connectables must be aware of the dimension they are in
- The dimension of the master must be known to all connectables
- Some checks need to account for the direction they are EnumFacing

I understand this is quite a big change and requires lots of testing and probably bug fixing. I'd be happy to help, of course.

E.g. I'm not sure about compatibility with old worlds. It might be necessary to handle that some more. Just ignore all the old data and refresh the network, maybe?

![00_outside](https://user-images.githubusercontent.com/205210/51440039-a6d94200-1cc2-11e9-8914-21dba65cd7fa.png)
![01_terminal](https://user-images.githubusercontent.com/205210/51440040-a6d94200-1cc2-11e9-9389-e4a205a0dda8.png)
![02_machine](https://user-images.githubusercontent.com/205210/51440038-a640ab80-1cc2-11e9-9d9e-b59997e375bc.png)

